### PR TITLE
fix: support unsigned ID tokens even when JOSE disables them

### DIFF
--- a/test/oidcc_token_test.erl
+++ b/test/oidcc_token_test.erl
@@ -90,6 +90,8 @@ retrieve_none_test() ->
         end,
     ok = meck:expect(httpc, request, HttpFun),
 
+    jose:unsecured_signing(false),
+
     ?assertMatch(
         {error,
             {none_alg_used, #oidcc_token{


### PR DESCRIPTION
By default, JOSE disables verification of `none` alg JWTs,
for (reasonable) security preferences. However,
`oidcc-client-test-idtoken-sig-none` says this is an optionally
supported use case. This updates the implementation of
`verify_signature` to return an error with the JWT/JWS values even when
JOSE is configured not to allow `none` signatures.