### PR TITLE
feat: function to locally validate a JWT

### DIFF
--- a/.github/workflows/part_docs.yml
+++ b/.github/workflows/part_docs.yml
@@ -20,13 +20,13 @@ jobs:
         with:
           version-file: .tool-versions
           version-type: strict
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4
         with:
           path: _build
           key: docs-build-${{ runner.os }}-${{ steps.setupBEAM.outputs.otp-version }}-${{ steps.setupBEAM.outputs.elixir-version }}-${{ hashFiles('rebar.config') }}
           restore-keys: |
             docs-build-{{ runner.os }}-${{ steps.setupBEAM.outputs.otp-version }}-${{ steps.setupBEAM.outputs.elixir-version }}-
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4
         with:
           path: deps
           key: docs-deps-${{ runner.os }}-${{ steps.setupBEAM.outputs.otp-version }}-${{ steps.setupBEAM.outputs.elixir-version }}-${{ hashFiles('rebar.config') }}

--- a/.github/workflows/part_publish.yml
+++ b/.github/workflows/part_publish.yml
@@ -25,13 +25,13 @@ jobs:
         with:
           version-file: .tool-versions
           version-type: strict
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4
         with:
           path: _build
           key: mix_hex_publish-build-${{ runner.os }}-${{ steps.setupBEAM.outputs.otp-version }}-${{ hashFiles('mix.exs') }}
           restore-keys: |
             mix_hex_publish-build-${{ runner.os }}-${{ steps.setupBEAM.outputs.otp-version }}-
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4
         with:
           path: deps
           key: mix_hex_publish-deps-${{ runner.os }}-${{ steps.setupBEAM.outputs.otp-version }}-${{ hashFiles('mix.exs') }}
@@ -54,13 +54,13 @@ jobs:
         with:
           version-file: .tool-versions
           version-type: strict
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4
         with:
           path: _build
           key: mix_hex_build-build-${{ runner.os }}-${{ steps.setupBEAM.outputs.otp-version }}-${{ hashFiles('mix.exs') }}
           restore-keys: |
             mix_hex_build-build-${{ runner.os }}-${{ steps.setupBEAM.outputs.otp-version }}-
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4
         with:
           path: deps
           key: mix_hex_build-deps-${{ runner.os }}-${{ steps.setupBEAM.outputs.otp-version }}-${{ hashFiles('mix.exs') }}

--- a/.github/workflows/part_test.yml
+++ b/.github/workflows/part_test.yml
@@ -46,7 +46,7 @@ jobs:
         with:
           version-file: .tool-versions
           version-type: strict
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4
         with:
           path: _build
           key: rebar_format-${{ runner.os }}-${{ steps.setupBEAM.outputs.otp-version }}-${{ hashFiles('rebar.config') }}
@@ -66,13 +66,13 @@ jobs:
         with:
           version-file: .tool-versions
           version-type: strict
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4
         with:
           path: _build
           key: mix_format-build-${{ runner.os }}-${{ steps.setupBEAM.outputs.otp-version }}-${{ hashFiles('mix.exs') }}
           restore-keys: |
             mix_format-build-${{ runner.os }}-${{ steps.setupBEAM.outputs.otp-version }}-
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4
         with:
           path: deps
           key: mix_format-deps-${{ runner.os }}-${{ steps.setupBEAM.outputs.otp-version }}-${{ hashFiles('mix.exs') }}
@@ -107,7 +107,7 @@ jobs:
           otp-version: ${{ matrix.otp }}
           rebar3-version: "${{ needs.detectToolVersions.outputs.rebarVersion }}"
           version-type: strict
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4
         with:
           path: _build
           key: eunit-${{ runner.os }}-${{ steps.setupBEAM.outputs.otp-version }}-${{ hashFiles('rebar.config') }}
@@ -146,7 +146,7 @@ jobs:
           otp-version: ${{ matrix.otp }}
           rebar3-version: "${{ needs.detectToolVersions.outputs.rebarVersion }}"
           version-type: strict
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4
         with:
           path: _build
           key: ct-${{ runner.os }}-${{ steps.setupBEAM.outputs.otp-version }}-${{ hashFiles('rebar.config') }}
@@ -188,13 +188,13 @@ jobs:
           rebar3-version: "${{ needs.detectToolVersions.outputs.rebarVersion }}"
           elixir-version: "${{ matrix.elixir }}"
           version-type: strict
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4
         with:
           path: _build
           key: mix_test-build-${{ runner.os }}-${{ steps.setupBEAM.outputs.otp-version }}-${{ steps.setupBEAM.outputs.elixir-version }}-${{ hashFiles('mix.exs') }}
           restore-keys: |
             mix_test-build-${{ runner.os }}-${{ steps.setupBEAM.outputs.otp-version }}-${{ steps.setupBEAM.outputs.elixir-version }}-
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4
         with:
           path: deps
           key: mix_test-deps-${{ runner.os }}-${{ steps.setupBEAM.outputs.otp-version }}-${{ steps.setupBEAM.outputs.elixir-version }}-${{ hashFiles('mix.exs') }}
@@ -222,7 +222,7 @@ jobs:
         with:
           version-file: .tool-versions
           version-type: strict
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4
         with:
           path: _build
           key: mix_test_coverage-${{ runner.os }}-${{ steps.setupBEAM.outputs.otp-version }}-${{ steps.setupBEAM.outputs.elixir-version }}-${{ hashFiles('mix.exs') }}
@@ -236,7 +236,7 @@ jobs:
           mkdir cover
           mv artifacts/*/*.coverdata cover
           rm -rf artifacts
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4
         with:
           path: deps
           key: mix_test_coverage-deps-${{ runner.os }}-${{ steps.setupBEAM.outputs.otp-version }}-${{ steps.setupBEAM.outputs.elixir-version }}-${{ hashFiles('mix.exs') }}
@@ -263,7 +263,7 @@ jobs:
         with:
           version-file: .tool-versions
           version-type: strict
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4
         with:
           path: _build
           key: cover-${{ runner.os }}-${{ steps.setupBEAM.outputs.otp-version }}-${{ hashFiles('rebar.config') }}
@@ -294,7 +294,7 @@ jobs:
         with:
           version-file: .tool-versions
           version-type: strict
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4
         with:
           path: _build
           key: lint-${{ runner.os }}-${{ steps.setupBEAM.outputs.otp-version }}-${{ hashFiles('rebar.config') }}
@@ -314,13 +314,13 @@ jobs:
         with:
           version-file: .tool-versions
           version-type: strict
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4
         with:
           path: _build
           key: credo-build-${{ runner.os }}-${{ steps.setupBEAM.outputs.otp-version }}-${{ hashFiles('mix.exs') }}
           restore-keys: |
             credo-build-${{ runner.os }}-${{ steps.setupBEAM.outputs.otp-version }}-
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4
         with:
           path: deps
           key: credo-deps-${{ runner.os }}-${{ steps.setupBEAM.outputs.otp-version }}-${{ hashFiles('mix.exs') }}
@@ -341,13 +341,13 @@ jobs:
         with:
           version-file: .tool-versions
           version-type: strict
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4
         with:
           path: _build
           key: dialyxir-build-${{ runner.os }}-${{ steps.setupBEAM.outputs.otp-version }}-${{ hashFiles('mix.exs') }}
           restore-keys: |
             dialyxir-build-${{ runner.os }}-${{ steps.setupBEAM.outputs.otp-version }}-
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4
         with:
           path: deps
           key: dialyxir-deps-${{ runner.os }}-${{ steps.setupBEAM.outputs.otp-version }}-${{ hashFiles('mix.exs') }}
@@ -368,7 +368,7 @@ jobs:
         with:
           version-file: .tool-versions
           version-type: strict
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4
         with:
           path: _build
           key: dialyzer-${{ runner.os }}-${{ steps.setupBEAM.outputs.otp-version }}-${{ hashFiles('rebar.config') }}
@@ -388,7 +388,7 @@ jobs:
         with:
           version-file: .tool-versions
           version-type: strict
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4
         with:
           path: _build
           key: hank-${{ runner.os }}-${{ steps.setupBEAM.outputs.otp-version }}-${{ hashFiles('rebar.config') }}

--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ The refactoring for `v3` and the certification is funded as an
   * [RP-Initiated](https://openid.net/specs/openid-connect-rpinitiated-1_0.html)
 * [JWT Secured Authorization Response Mode for OAuth 2.0 (JARM)](https://openid.net/specs/oauth-v2-jarm-final.html)
 * [Demonstrating Proof of Possession (DPoP)](https://www.rfc-editor.org/rfc/rfc9449)
+* [OAuth 2 Purpose Request Parameter](https://cdn.connectid.com.au/specifications/oauth2-purpose-01.html)
 * Profiles
   * [FAPI 2.0 Security Profile](https://openid.bitbucket.io/fapi/fapi-2_0-security-profile.html)
   * [FAPI 2.0 Message Signing](https://openid.bitbucket.io/fapi/fapi-2_0-message-signing.html)

--- a/lib/oidcc/token.ex
+++ b/lib/oidcc/token.ex
@@ -304,6 +304,52 @@ defmodule Oidcc.Token do
       )
 
   @doc """
+  Validate JWT
+
+  Validates a generic JWT (such as an access token) from the given provider.
+  Useful if the issuer is shared between multiple applications, and the access token
+  generated for a user at one client is used to validate their access at another client.
+
+  ## Examples
+
+      iex> {:ok, pid} =
+      ...>   Oidcc.ProviderConfiguration.Worker.start_link(%{
+      ...>     issuer: "https://api.login.yahoo.com"
+      ...>   })
+      ...>
+      ...> {:ok, client_context} =
+      ...>   Oidcc.ClientContext.from_configuration_worker(
+      ...>     pid,
+      ...>     "client_id",
+      ...>     "client_secret"
+      ...>   )
+      ...>
+      ...> #Get JWT from Authorization header
+      ...> jwt = "jwt"
+      ...>
+      ...> opts = %{
+      ...>   signing_algs: client_context.provider_configuration.id_token_signing_alg_values_supported
+      ...> }
+      ...>
+      ...> Oidcc.Token.validate_jwt(jwt, client_context, opts)
+      ...> # => {:ok, %{"sub" => "sub", ... }}
+
+  """
+  @doc since: "3.0.0"
+  @spec validate_jwt(
+          jwt :: String.t(),
+          client_context :: ClientContext.t(),
+          opts :: :oidcc_token.validate_jwt_opts()
+        ) :: {:ok, :oidcc_jwt_util.claims()} | {:error, :oidcc_token.error()}
+  def validate_jwt(jwt, client_context, opts),
+    do:
+      :oidcc_token.validate_jwt(
+        jwt,
+        ClientContext.struct_to_record(client_context),
+        opts
+      )
+
+  @doc """
   Retrieve JSON Web Token (JWT) Profile Token
 
   See https://datatracker.ietf.org/doc/html/rfc7523#section-4

--- a/src/oidcc_profile.erl
+++ b/src/oidcc_profile.erl
@@ -17,7 +17,7 @@
 -export_type([opts_no_profiles/0]).
 -export_type([error/0]).
 
--type profile() :: fapi2_security_profile | fapi2_message_signing.
+-type profile() :: fapi2_security_profile | fapi2_message_signing | fapi2_connectid_au.
 -type opts() :: #{
     profiles => [profile()],
     require_pkce => boolean(),
@@ -92,6 +92,61 @@ apply_profiles(
     %% Also require everything from FAPI2 Security Profile
     Opts = Opts0#{profiles => [fapi2_security_profile | RestProfiles]},
     apply_profiles(ClientContext, Opts);
+apply_profiles(
+    #oidcc_client_context{} = ClientContext0,
+    #{profiles := [fapi2_connectid_au | RestProfiles]} = Opts0
+) ->
+    %% FAPI2 ConnectID profile
+    maybe
+        %% Require everything from FAPI2 Message Signing
+        {ok, ClientContext1, Opts1} ?=
+            apply_profiles(ClientContext0, Opts0#{
+                profiles => [fapi2_message_signing | RestProfiles]
+            }),
+        %% Require `purpose' field
+        Opts2 = Opts1#{require_purpose => true},
+        %% If a PAR endpoint is present in the mTLS aliases, use that as the default
+        #oidcc_client_context{provider_configuration = Configuration1} = ClientContext1,
+        Configuration2 =
+            case Configuration1#oidcc_provider_configuration.mtls_endpoint_aliases of
+                #{
+                    <<"pushed_authorization_request_endpoint">> := MtlsParEndpoint
+                } ->
+                    Configuration1#oidcc_provider_configuration{
+                        pushed_authorization_request_endpoint = MtlsParEndpoint
+                    };
+                _ ->
+                    Configuration1
+            end,
+        %% If the token endpoint is present in the mTLS aliases, use that as the default
+        Configuration3 =
+            case Configuration2#oidcc_provider_configuration.mtls_endpoint_aliases of
+                #{
+                    <<"token_endpoint">> := MtlsTokenEndpoint
+                } ->
+                    Configuration2#oidcc_provider_configuration{
+                        token_endpoint = MtlsTokenEndpoint
+                    };
+                _ ->
+                    Configuration2
+            end,
+        %% If the userinfo endpoint is present in the mTLS aliases, use that as the default
+        Configuration4 =
+            case Configuration3#oidcc_provider_configuration.mtls_endpoint_aliases of
+                #{
+                    <<"userinfo_endpoint">> := MtlsUserinfoEndpoint
+                } ->
+                    Configuration3#oidcc_provider_configuration{
+                        userinfo_endpoint = MtlsUserinfoEndpoint
+                    };
+                _ ->
+                    Configuration3
+            end,
+        ClientContext2 = ClientContext1#oidcc_client_context{
+            provider_configuration = Configuration4
+        },
+        {ok, ClientContext2, Opts2}
+    end;
 apply_profiles(#oidcc_client_context{}, #{profiles := [UnknownProfile | _]}) ->
     {error, {unknown_profile, UnknownProfile}};
 apply_profiles(#oidcc_client_context{} = ClientContext, #{profiles := []} = Opts0) ->

--- a/test/oidcc_authorization_test.erl
+++ b/test/oidcc_authorization_test.erl
@@ -65,6 +65,9 @@ create_redirect_url_test() ->
     Opts5 = maps:merge(BaseOpts, #{pkce_verifier => <<"foo">>}),
     Opts6 = maps:merge(Opts5, #{require_pkce => true}),
     Opts7 = maps:merge(BaseOpts, #{require_pkce => true}),
+    Opts8 = maps:merge(BaseOpts, #{purpose => <<"purpose">>}),
+    Opts9 = maps:merge(Opts8, #{purpose_required => true}),
+    Opts10 = maps:merge(BaseOpts, #{purpose_required => true}),
 
     {ok, Url1} = oidcc_authorization:create_redirect_url(ClientContext, BaseOpts),
     {ok, Url2} = oidcc_authorization:create_redirect_url(ClientContext, Opts1),
@@ -75,6 +78,8 @@ create_redirect_url_test() ->
     {ok, Url7} = oidcc_authorization:create_redirect_url(PkcePlainClientContext, Opts5),
     {ok, Url8} = oidcc_authorization:create_redirect_url(NoPkceClientContext, Opts5),
     {ok, Url9} = oidcc_authorization:create_redirect_url(PkcePlainClientContext, Opts6),
+    {ok, Url10} = oidcc_authorization:create_redirect_url(ClientContext, Opts8),
+    {ok, Url11} = oidcc_authorization:create_redirect_url(ClientContext, Opts9),
 
     ExpUrl1 =
         <<"https://my.provider/auth?scope=openid&response_type=code&client_id=client_id&redirect_uri=https%3A%2F%2Fmy.server%2Freturn&test=id">>,
@@ -110,6 +115,12 @@ create_redirect_url_test() ->
 
     ?assertEqual(iolist_to_binary(Url9), iolist_to_binary(Url7)),
 
+    ExpUrl10 =
+        <<"https://my.provider/auth?scope=openid&purpose=purpose&response_type=code&client_id=client_id&redirect_uri=https%3A%2F%2Fmy.server%2Freturn&test=id">>,
+    ?assertEqual(ExpUrl10, iolist_to_binary(Url10)),
+
+    ?assertEqual(iolist_to_binary(Url11), iolist_to_binary(Url10)),
+
     ?assertEqual(
         {error, no_supported_code_challenge},
         oidcc_authorization:create_redirect_url(NoPkceClientContext, Opts6)
@@ -118,6 +129,11 @@ create_redirect_url_test() ->
     ?assertEqual(
         {error, pkce_verifier_required},
         oidcc_authorization:create_redirect_url(ClientContext, Opts7)
+    ),
+
+    ?assertEqual(
+        {error, purpose_required},
+        oidcc_authorization:create_redirect_url(ClientContext, Opts10)
     ),
 
     ok.

--- a/test/oidcc_client_context_test.erl
+++ b/test/oidcc_client_context_test.erl
@@ -163,6 +163,62 @@ apply_profiles_fapi2_message_signing_test() ->
 
     ok.
 
+apply_profiles_fapi2_connectid_au_test() ->
+    ClientContext0 = client_context_fixture(),
+    Opts0 = #{
+        profiles => [fapi2_connectid_au]
+    },
+
+    ProfileResult = oidcc_client_context:apply_profiles(ClientContext0, Opts0),
+
+    ?assertMatch(
+        {ok, #oidcc_client_context{}, #{}},
+        ProfileResult
+    ),
+
+    {ok, ClientContext, Opts} = ProfileResult,
+
+    ?assertMatch(
+        #oidcc_client_context{
+            provider_configuration = #oidcc_provider_configuration{
+                token_endpoint = <<"https://my.provider/tls/token">>,
+                userinfo_endpoint = <<"https://my.provider/tls/userinfo">>,
+                response_types_supported = [<<"code">>],
+                response_modes_supported = [<<"jwt">>, <<"query.jwt">>],
+                id_token_signing_alg_values_supported = [<<"EdDSA">>],
+                userinfo_signing_alg_values_supported = [
+                    <<"PS256">>,
+                    <<"PS384">>,
+                    <<"PS512">>,
+                    <<"ES256">>,
+                    <<"ES384">>,
+                    <<"ES512">>,
+                    <<"EdDSA">>
+                ],
+                code_challenge_methods_supported = [<<"S256">>],
+                require_pushed_authorization_requests = true,
+                pushed_authorization_request_endpoint = undefined,
+                authorization_response_iss_parameter_supported = true
+            }
+        },
+        ClientContext
+    ),
+
+    ?assertMatch(
+        #{
+            preferred_auth_methods := [private_key_jwt, tls_client_auth],
+            require_pkce := true,
+            require_purpose := true,
+            trusted_audiences := [],
+            request_opts := #{
+                ssl := _
+            }
+        },
+        Opts
+    ),
+
+    ok.
+
 apply_profiles_unknown_test() ->
     ClientContext = client_context_fixture(),
     Opts = #{

--- a/test/oidcc_token_SUITE.erl
+++ b/test/oidcc_token_SUITE.erl
@@ -5,13 +5,14 @@
 -export([init_per_suite/1]).
 -export([retrieves_client_credentials_token/1]).
 -export([retrieves_jwt_profile_token/1]).
+-export([validates_access_token/1]).
 
 -include_lib("common_test/include/ct.hrl").
 -include_lib("jose/include/jose_jwk.hrl").
 -include_lib("oidcc/include/oidcc_token.hrl").
 -include_lib("stdlib/include/assert.hrl").
 
-all() -> [retrieves_jwt_profile_token, retrieves_client_credentials_token].
+all() -> [retrieves_jwt_profile_token, retrieves_client_credentials_token, validates_access_token].
 
 init_per_suite(_Config) ->
     {ok, _} = application:ensure_all_started(oidcc),
@@ -109,6 +110,44 @@ retrieves_client_credentials_token(_Config) ->
         oidcc_token:client_credentials(ZitadelClientContext, #{
             scope => [<<"openid">>, <<"profile">>]
         })
+    ),
+
+    ok.
+
+validates_access_token(_Config) ->
+    PrivDir = code:priv_dir(oidcc),
+    Issuer = <<"https://erlef-test-w4a8z2.zitadel.cloud">>,
+
+    {ok, ZitadelConfigurationPid} =
+        oidcc_provider_configuration_worker:start_link(#{
+            issuer => Issuer
+        }),
+
+    {ok, ZitadelClientCredentialsJson} = file:read_file(
+        PrivDir ++ "/test/fixtures/zitadel-client-credentials.json"
+    ),
+    #{
+        <<"clientId">> := ZitadelClientCredentialsClientId,
+        <<"clientSecret">> := ZitadelClientCredentialsClientSecret
+    } = jose:decode(ZitadelClientCredentialsJson),
+
+    {ok, ZitadelClientContext} = oidcc_client_context:from_configuration_worker(
+        ZitadelConfigurationPid,
+        ZitadelClientCredentialsClientId,
+        ZitadelClientCredentialsClientSecret
+    ),
+
+    {ok, Token} = oidcc_token:client_credentials(ZitadelClientContext, #{
+        scope => [<<"openid">>, <<"profile">>]
+    }),
+
+    #oidcc_token{access = #oidcc_token_access{token = AccessToken}} = Token,
+    ?assertMatch(
+        {ok, #{
+            <<"iss">> := Issuer,
+            <<"aud">> := [ZitadelClientCredentialsClientId]
+        }},
+        oidcc_token:validate_jwt(AccessToken, ZitadelClientContext, #{signing_algs => [<<"RS256">>]})
     ),
 
     ok.


### PR DESCRIPTION
Many access tokens are JWTs, which clients can validate without needing to use the `token_introspection` endpoint. This allows multiple clients using the same issuer to use access tokens as a means of validation between them.

Please go the the `Preview` tab and select the appropriate sub-template:

- [🐞 Bug Fix](?expand=1&template=FIX.md)
- [⚙ Improvement](?expand=1&template=IMPROVEMENT.md)
- [🎉 New Feature](?expand=1&template=NEW_FEATURE.md)
